### PR TITLE
Executemany pipeline

### DIFF
--- a/psycopg/psycopg/cursor_async.py
+++ b/psycopg/psycopg/cursor_async.py
@@ -14,6 +14,7 @@ from .abc import Query, Params
 from .copy import AsyncCopy
 from .rows import Row, RowMaker, AsyncRowFactory
 from .cursor import BaseCursor
+from ._pipeline import Pipeline
 
 if TYPE_CHECKING:
     from .connection_async import AsyncConnection
@@ -86,9 +87,24 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
         returning: bool = False,
     ) -> None:
         try:
-            async with self._conn.lock:
+            if Pipeline.is_supported():
+                # If there is already a pipeline, ride it, in order to avoid
+                # sending unnecessary Sync.
+                async with self._conn.lock:
+                    p = self._conn._pipeline
+                    if p:
+                        await self._conn.wait(
+                            self._executemany_gen_pipeline(query, params_seq, returning)
+                        )
+                # Otherwise, make a new one
+                if not p:
+                    async with self._conn.pipeline(), self._conn.lock:
+                        await self._conn.wait(
+                            self._executemany_gen_pipeline(query, params_seq, returning)
+                        )
+            else:
                 await self._conn.wait(
-                    self._executemany_gen(query, params_seq, returning)
+                    self._executemany_gen_no_pipeline(query, params_seq, returning)
                 )
         except e.Error as ex:
             raise ex.with_traceback(None)
@@ -172,7 +188,10 @@ class AsyncCursor(BaseCursor["AsyncConnection[Any]", Row]):
             yield copy
 
     async def _fetch_pipeline(self) -> None:
-        if not self.pgresult and self._conn._pipeline:
+        if (
+            self._execmany_returning is not False
+            and not self.pgresult
+            and self._conn._pipeline
+        ):
             async with self._conn.lock:
                 await self._conn.wait(self._conn._pipeline._fetch_gen(flush=True))
-            assert self.pgresult

--- a/psycopg/psycopg/errors.py
+++ b/psycopg/psycopg/errors.py
@@ -199,6 +199,14 @@ class ConnectionTimeout(OperationalError):
     """
 
 
+class PipelineAborted(OperationalError):
+    """
+    Raised when a operation fails because the current pipeline is in aborted state.
+
+    Subclass of `~psycopg.OperationalError`.
+    """
+
+
 class Diagnostic:
     """Details from a database error report."""
 

--- a/tests/fix_pq.py
+++ b/tests/fix_pq.py
@@ -1,8 +1,15 @@
 import sys
+from typing import Iterator, List, NamedTuple
+from tempfile import TemporaryFile
 
 import pytest
 
 from .utils import check_libpq_version
+
+try:
+    from psycopg import pq
+except ImportError:
+    pq = None  # type: ignore
 
 
 def pytest_report_header(config):
@@ -28,8 +35,6 @@ def pytest_configure(config):
 
 
 def pytest_runtest_setup(item):
-    from psycopg import pq
-
     for m in item.iter_markers(name="libpq"):
         assert len(m.args) == 1
         msg = check_libpq_version(pq.version(), m.args[0])
@@ -51,9 +56,71 @@ def libpq():
         assert libname, "libpq libname not found"
         return ctypes.pydll.LoadLibrary(libname)
     except Exception as e:
-        from psycopg import pq
-
         if pq.__impl__ == "binary":
             pytest.skip(f"can't load libpq for testing: {e}")
         else:
             raise
+
+
+@pytest.fixture
+def trace(libpq):
+    pqver = pq.__build_version__ or pq.version()
+    if pqver < 140000:
+        pytest.skip(f"trace not available on libpq {pqver}")
+    if sys.platform != "linux":
+        pytest.skip(f"trace not available on {sys.platform}")
+
+    yield Tracer()
+
+
+class Tracer:
+    def trace(self, conn):
+        pgconn: "pq.abc.PGconn"
+
+        if hasattr(conn, "exec_"):
+            pgconn = conn
+        elif hasattr(conn, "cursor"):
+            pgconn = conn.pgconn
+        else:
+            raise Exception()
+
+        return TraceLog(pgconn)
+
+
+class TraceLog:
+    def __init__(self, pgconn: "pq.abc.PGconn"):
+        self.pgconn = pgconn
+        self.tempfile = TemporaryFile(buffering=0)
+        pgconn.trace(self.tempfile.fileno())
+        pgconn.set_trace_flags(pq.Trace.SUPPRESS_TIMESTAMPS)
+
+    def __del__(self):
+        if self.pgconn.status == pq.ConnStatus.OK:
+            self.pgconn.untrace()
+        self.tempfile.close()
+
+    def __iter__(self) -> "Iterator[TraceEntry]":
+        self.tempfile.seek(0)
+        data = self.tempfile.read()
+        for entry in self._parse_entries(data):
+            yield entry
+
+    def _parse_entries(self, data: bytes) -> "Iterator[TraceEntry]":
+        for line in data.splitlines():
+            direction, length, type, *content = line.split(b"\t")
+            yield TraceEntry(
+                direction=direction.decode(),
+                length=int(length.decode()),
+                type=type.decode(),
+                # Note: the items encoding is not very solid: no escaped
+                # backslash, no escaped quotes.
+                # At the moment we don't need a proper parser.
+                content=[content[0]] if content else [],
+            )
+
+
+class TraceEntry(NamedTuple):
+    direction: str
+    length: int
+    type: str
+    content: List[bytes]

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -316,8 +316,13 @@ def test_executemany_no_result(conn, execmany):
         returning=True,
     )
     assert cur.rowcount == 2
+    assert cur.statusmessage.startswith("INSERT")
     with pytest.raises(psycopg.ProgrammingError):
         cur.fetchone()
+    pgresult = cur.pgresult
+    assert cur.nextset()
+    assert cur.statusmessage.startswith("INSERT")
+    assert pgresult is not cur.pgresult
     assert cur.nextset() is None
 
 

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -304,8 +304,13 @@ async def test_executemany_no_result(aconn, execmany):
         returning=True,
     )
     assert cur.rowcount == 2
+    assert cur.statusmessage.startswith("INSERT")
     with pytest.raises(psycopg.ProgrammingError):
         await cur.fetchone()
+    pgresult = cur.pgresult
+    assert cur.nextset()
+    assert cur.statusmessage.startswith("INSERT")
+    assert pgresult is not cur.pgresult
     assert cur.nextset() is None
 
 


### PR DESCRIPTION
Recreated from original PR: https://github.com/psycopg/psycopg/pull/260

Optimization of `Cursor.executemany()` using pipelines (#145). 

This branch is based on @dlax pipeline4 branch (#175) and will be merged after the other MR is.

Speedup looks in the region of the 2.5x improvement.

```python
# test-execmany.py 
import psycopg
cnn = psycopg.connect("host=localhost", autocommit=True)
cur = cnn.cursor()
cur.execute("""
    create temp table testmany (
        id serial primary key, n1 int, n2 int, s1 text, s2 text)
    """)
cur.executemany(
    "in...